### PR TITLE
New test for #6

### DIFF
--- a/test/acceptance/virtualbox/Vagrantfile
+++ b/test/acceptance/virtualbox/Vagrantfile
@@ -20,6 +20,21 @@ Vagrant.configure("2") do |config|
 
   end
 
+  config.vm.define :gh6 do |gh6|
+    gh6.puppet_install.puppet_version = '2.7.23'
+
+    gh6.vm.box = "chef/ubuntu-12.04-i386"
+    gh6.vm.provision "shell", inline: "puppet --version"
+
+    gh6.vm.provision :puppet do |puppet|
+      puppet.manifests_path = File.expand_path('../../../support/manifests', __FILE__)
+      puppet.manifest_file  = "base.pp"
+    end
+
+    gh6.vm.provision "shell", inline: "puppet --version"
+
+  end
+
   config.vm.define :centos do |centos|
     centos.puppet_install.puppet_version = :latest
     centos.vm.box = "chef/centos-6.5"


### PR DESCRIPTION
Test for installing older versions of puppet and needing to require facter (deb is explicitly tied to facter < 2.0.0)
