### PR TITLE
.idea folder exclude (all jetbrains IDEs).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 bin/
 .vagrant/
+.idea/


### PR DESCRIPTION
Hi there,

I use many of the jetbrains IDEs.

The default folder for all their apps is .idea.

I'm hoping  you can accept this to avoid me accidentally attempting a commit to master of rubymine, idea, etc.
