### PR TITLE
Fixes unlink code to work on Windows machines

### DIFF
--- a/lib/vagrant-puppet-install/action/install_puppet.rb
+++ b/lib/vagrant-puppet-install/action/install_puppet.rb
@@ -173,7 +173,18 @@ module VagrantPlugins
 
         def recover(env)
           if @script_tmp_path && File.exist?(@script_tmp_path)
-            File.unlink(@script_tmp_path)
+            # Try extra hard to unlink the file so that it reliably works
+            # on Windows hosts as well, see:
+            # http://alx.github.io/2009/01/27/ruby-wundows-unlink.html
+            file_deleted = false
+            until file_deleted
+              begin
+                File.unlink(@script_tmp_path)
+                file_deleted = true
+              rescue Errno::EACCES
+                @logger.debug("failed to unlink #{@script_tmp_path}. retry...")
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
* Fixes https://github.com/petems/vagrant-puppet-install/issues/42
* Taken from https://github.com/chef/vagrant-omnibus/pull/65/
* Which took it from http://alx.github.io/2009/01/27/ruby-wundows-unlink.html