### PR TITLE
Adds acceptance test for Fedora 23

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :acceptance do
   gem 'vagrant-digitalocean', '~> 0.5.3'
   gem 'vagrant-aws', '~> 0.4.0'
   gem 'vagrant-rackspace', '~> 0.1.4'
+  gem 'vagrant-vbguest', '~> 0.11.0'
 end
 
 group :docs do

--- a/test/acceptance/virtualbox/Vagrantfile
+++ b/test/acceptance/virtualbox/Vagrantfile
@@ -36,6 +36,30 @@ Vagrant.configure('2') do |config|
     trusty_361.vm.provision 'shell', inline: 'puppet --version'
   end
 
+  config.vm.define :fedora_23 do |fedora_23|
+    fedora_23.vm.box = "fedora/23-cloud-base"
+    fedora_23.puppet_install.puppet_version = :latest
+
+    fedora_23.vm.provision :puppet do |puppet|
+      puppet.environment_path = File.expand_path('../../../support/environments', __FILE__)
+      puppet.environment = "vagrant"
+    end
+
+    fedora_23.vm.provision 'shell', inline: 'puppet --version'
+  end
+
+  config.vm.define :fedora_384 do |fedora_384|
+    fedora_384.vm.box = "fedora/23-cloud-base"
+    fedora_384.puppet_install.puppet_version = '3.8.4'
+
+    fedora_384.vm.provision :puppet do |puppet|
+      puppet.environment_path = File.expand_path('../../../support/environments', __FILE__)
+      puppet.environment = "vagrant"
+    end
+
+    fedora_384.vm.provision 'shell', inline: 'puppet --version'
+  end
+
   config.vm.define :trusty_ubuntu_box do |trusty_ubuntu_box|
     trusty_ubuntu_box.puppet_install.puppet_version = :latest
     trusty_ubuntu_box.puppet_install.install_url = 'https://gist.githubusercontent.com/petems/6723c2eedb9d32d7ad97/raw/990ff448f6430aa015e208668a3cecb3f1db0d4b/purge_old_install_new.sh'

--- a/test/acceptance/virtualbox/Vagrantfile
+++ b/test/acceptance/virtualbox/Vagrantfile
@@ -3,6 +3,7 @@
 
 # plugins don't seem to be auto-loaded from the bundle
 require 'vagrant-puppet-install'
+require 'vagrant-vbguest'
 
 Vagrant.configure('2') do |config|
   config.vm.define :no_config_set do |no_config_set|


### PR DESCRIPTION
Will require changes to the puppet-install-shell script (see https://github.com/petems/puppet-install-shell/pull/47)

When working, can close https://github.com/petems/vagrant-puppet-install/issues/41

