### PR TITLE
fix syntax error in install_puppet.rb

### DIFF
--- a/lib/vagrant-puppet-install/action/install_puppet.rb
+++ b/lib/vagrant-puppet-install/action/install_puppet.rb
@@ -65,7 +65,7 @@ module VagrantPlugins
           else
             if @machine.config.puppet_install.puppet_version == 'latest' || @machine.config.puppet_install.puppet_version.match(/^6\..+/)
               'https://raw.githubusercontent.com/petems/puppet-install-shell/master/install_puppet_6_agent.sh'
-            if @machine.config.puppet_install.puppet_version.match(/^5\..+/)
+            elsif @machine.config.puppet_install.puppet_version.match(/^5\..+/)
               'https://raw.githubusercontent.com/petems/puppet-install-shell/master/install_puppet_5_agent.sh'
             elsif @machine.config.puppet_install.puppet_version.match(/^4\..+/)
               'https://raw.githubusercontent.com/petems/puppet-install-shell/master/install_puppet_agent.sh'


### PR DESCRIPTION
Changes for Puppet 6 support introduced a breaking typo; this seems like the appropriate fix.